### PR TITLE
Added dynamic `default` (defaults from translation payload)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -163,6 +163,14 @@ You can also use `default` value. This value is used in case there is no appropr
 {{placeholder; default:This is default value;}}
 ```
 
+The `default` value can be set also dynamically using the translation payload in your `.svelte` file. For example:
+
+```javascript
+$t(`error.${code}`, { default: $t('error.default') })
+```
+This value is used in case no `default` value is defined within the placeholder itself. For more, see `Dynamic default` section in [custom-modifiers](https://github.com/jarda-svoboda/sveltekit-i18n/tree/master/examples/custom-modifiers) example.
+
+
 ### Modifiers
 Modifiers don't represent the payload value directly, but they can use it for further calculations. Currently, these modifiers are in place:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -163,13 +163,12 @@ You can also use `default` value. This value is used in case there is no appropr
 {{placeholder; default:This is default value;}}
 ```
 
-The `default` value can be set also dynamically using the translation payload in your `.svelte` file. For example:
+The `default` value can be also set dynamically using the translation payload in your `.svelte` file. For example:
 
 ```javascript
 $t(`error.${code}`, { default: $t('error.default') })
 ```
-This value is used in case no `default` value is defined within the placeholder itself. For more, see `Dynamic default` section in [custom-modifiers](https://github.com/jarda-svoboda/sveltekit-i18n/tree/master/examples/custom-modifiers) example.
-
+This value is used in case no `default` value is defined within the placeholder definition itself. For more, see `Dynamic default` section in [custom-modifiers](https://github.com/jarda-svoboda/sveltekit-i18n/tree/master/examples/custom-modifiers) example.
 
 ### Modifiers
 Modifiers don't represent the payload value directly, but they can use it for further calculations. Currently, these modifiers are in place:

--- a/examples/custom-modifiers/src/lib/translations/cs/content.json
+++ b/examples/custom-modifiers/src/lib/translations/cs/content.json
@@ -1,6 +1,7 @@
 {
   "title_built-in": "Vestavěné modifikátory",
   "title_custom": "Vlastní modifikátory",
+  "title_dynamic_default": "Proměnná výchozí hodnota",
   "modifier_eq_string": "{{value; male:On; female:Ona; default:Někdo}} má psa.",
   "modifier_ne_string": "Ten pes není {{value:ne; male:jeho; female:její;}}.",
   "modifier_eq": "Hodnota {{value; 10:je; default:není;}} rovna deseti",
@@ -13,5 +14,10 @@
   "modifier_date": "Lokální formát data: {{value:date;}}",
   "modifier_ago": "Relativní: {{value:ago;}}",
   "modifier_test": "Testovací modifikátor: {{value:test; default:žádný vstup}}",
-  "modifier_currency": "Měna: {{value:currency; currency:CZK; ratio: 22.4;}}"
+  "modifier_currency": "Měna: {{value:currency; currency:CZK; ratio: 22.4;}}",
+  "error": {
+    "404": "Nenalezeno.",
+    "500": "Chyba serveru.",
+    "default": "Něco se pokazilo."
+  }
 }

--- a/examples/custom-modifiers/src/lib/translations/en/content.json
+++ b/examples/custom-modifiers/src/lib/translations/en/content.json
@@ -1,6 +1,7 @@
 {
   "title_built-in": "Built-in Modifiers",
   "title_custom": "Custom Modifiers",
+  "title_dynamic_default": "Dynamic default",
   "modifier_eq_string": "{{value; male:He; female:She; default:No one}} has a dog.",
   "modifier_ne_string": "The dog is not {{value:ne; male:his; female:her;}}.",
   "modifier_eq": "Value {{value; 10:is; default:is not;}} equal to ten",
@@ -13,5 +14,10 @@
   "modifier_date": "Local date format: {{value:date;}}",
   "modifier_ago": "Relative: {{value:ago;}}",
   "modifier_test": "Test modifier: {{value:test; default:no input}}",
-  "modifier_currency": "Currency: {{value:currency; currency:USD; ratio: 1;}}"
+  "modifier_currency": "Currency: {{value:currency; currency:USD; ratio: 1;}}",
+  "error": {
+    "404": "Not found.",
+    "500": "Internal server error.",
+    "default": "Some error occurred."
+  }
 }

--- a/examples/custom-modifiers/src/lib/translations/index.js
+++ b/examples/custom-modifiers/src/lib/translations/index.js
@@ -3,7 +3,7 @@ import lang from './lang.json';
 import * as customModifiers from './modifiers';
 
 /** @type {import('sveltekit-i18n').Config} */
-export const config = {
+const config = {
   initLocale: 'en',
   translations: {
     en: { lang },
@@ -24,6 +24,12 @@ export const config = {
   customModifiers,
 };
 
-export const { t, loading, locales, locale, loadConfig } = new i18n();
+export const { t, loading, locales, locale, translations } = new i18n(config);
 
-loading.subscribe(($loading) => $loading && console.log('Loading translations...'));
+loading.subscribe(async ($loading) => {
+  if ($loading) {
+    console.log('Loading translations...');
+    await loading.toPromise();
+    console.log('Updated translations', translations.get());
+  }
+});

--- a/examples/custom-modifiers/src/routes/__layout.svelte
+++ b/examples/custom-modifiers/src/routes/__layout.svelte
@@ -1,8 +1,8 @@
 <script context="module">
-  import { t, locales, locale, loadConfig, config } from '$lib/translations';
+  import { t, loading, locales, locale } from '$lib/translations';
 
   export const load = async () => {
-    await loadConfig(config);
+    await loading.toPromise();
 
     return {};
   }

--- a/examples/custom-modifiers/src/routes/index.svelte
+++ b/examples/custom-modifiers/src/routes/index.svelte
@@ -8,6 +8,7 @@
   const currency = 100;
   const test = 'TEST_VALUE';
   const gender = writable('female');
+  const error = writable(404);
 </script>
 
 <h1>{$t('content.title_built-in')}</h1>
@@ -38,3 +39,11 @@
 <h1>{$t('content.title_custom')}</h1>
 <p>{$t('content.modifier_test', { value: test})}</p>
 <p>{$t('content.modifier_currency', { value: currency})}</p>
+
+<h1>{$t('content.title_dynamic_default')}</h1>
+<b>Set error code:</b>
+<button on:click="{() => {$error = 404}}">404</button>
+<button on:click="{() => {$error = 500}}">500</button>
+<button on:click="{() => {$error = undefined}}">(undefined)</button>
+<br />
+<p>{$t(`content.error.${$error}`, { default: $t('content.error.default')})} ({$error})</p>

--- a/examples/locale-router-static/src/lib/translations/cs/error.json
+++ b/examples/locale-router-static/src/lib/translations/cs/error.json
@@ -1,3 +1,6 @@
 {
-  "shit.happens": "No toto..."
+  "shit.happens": "No toto...",
+  "404": "Stránka nenalezena.",
+  "500": "Interní chyba serveru.",
+  "default": "Něco se pokazilo."
 }

--- a/examples/locale-router-static/src/lib/translations/de/error.json
+++ b/examples/locale-router-static/src/lib/translations/de/error.json
@@ -1,3 +1,6 @@
 {
-  "shit.happens": "Auweh..."
+  "shit.happens": "Auweh...",
+  "404": "Seite nicht gefunden.",
+  "500": "Server interner Fehler.",
+  "default": "Ein Fehler ist aufgetreten."
 }

--- a/examples/locale-router-static/src/lib/translations/en/error.json
+++ b/examples/locale-router-static/src/lib/translations/en/error.json
@@ -1,3 +1,6 @@
 {
-  "shit.happens": "Oh, dear..."
+  "shit.happens": "Oh, dear...",
+  "404": "Page not found.",
+  "500": "Server internal error.",
+  "default": "Some error occurred."
 }

--- a/examples/locale-router-static/src/routes/__error.svelte
+++ b/examples/locale-router-static/src/routes/__error.svelte
@@ -20,7 +20,7 @@
 
 <div class="content">
   <h1>{$t('error.shit.happens')} ({status})</h1>
-  <p>{$t(`error.${status}.some.info`)}</p>
+  <p>{$t(`error.${status}`, { default: $t('error.default') })}</p>
   <br>
   <br>
   {$locale} – {$t(`lang.${$locale}`)}

--- a/examples/locale-router/src/lib/translations/cs/error.json
+++ b/examples/locale-router/src/lib/translations/cs/error.json
@@ -1,3 +1,6 @@
 {
-  "shit.happens": "No toto..."
+  "shit.happens": "No toto...",
+  "404": "Stránka nenalezena.",
+  "500": "Interní chyba serveru.",
+  "default": "Něco se pokazilo."
 }

--- a/examples/locale-router/src/lib/translations/de/error.json
+++ b/examples/locale-router/src/lib/translations/de/error.json
@@ -1,3 +1,6 @@
 {
-  "shit.happens": "Auweh..."
+  "shit.happens": "Auweh...",
+  "404": "Seite nicht gefunden.",
+  "500": "Server interner Fehler.",
+  "default": "Ein Fehler ist aufgetreten."
 }

--- a/examples/locale-router/src/lib/translations/en/error.json
+++ b/examples/locale-router/src/lib/translations/en/error.json
@@ -1,3 +1,6 @@
 {
-  "shit.happens": "Oh, dear..."
+  "shit.happens": "Oh, dear...",
+  "404": "Page not found.",
+  "500": "Server internal error.",
+  "default": "Some error occurred."
 }

--- a/examples/locale-router/src/routes/__error.svelte
+++ b/examples/locale-router/src/routes/__error.svelte
@@ -19,7 +19,7 @@
 
 <div class="content">
   <h1>{$t('error.shit.happens')} ({status})</h1>
-  <p>{$t(`error.${status}.some.info`)}</p>
+  <p>{$t(`error.${status}`, { default: $t('error.default') })}</p>
   <br>
   <br>
   {$locale} – {$t(`lang.${$locale}`)}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -53,7 +53,7 @@ const unesc = (text:string) => text.replace(/\\(?=:|;|{|})/g, '');
 
 const placeholders = (text: string, vars: Record<any, any> = {}, customModifiers: CustomModifiers = {}, locale?: string) => text.replace(/{{\s*(?:(?!{{|}}).)+\s*}}/g, (placeholder: string) => {
   const key = unesc(`${placeholder.match(/(?!{|\s).+?(?!\\[:;]).(?=\s*(?:[:;]|}}$))/)}`);
-  const value = vars[key];
+  const value = vars?.[key];
   const [,defaultValue = ''] = useDefault(placeholder.match(/.+?(?!\\;).;\s*default\s*:\s*([^\s:;].+?(?:\\[:;]|[^;\s}])*)(?=\s*(?:;|}}$))/i), []);
 
   let [,modifierKey = ''] = useDefault(placeholder.match(/{{\s*(?:[^;]|(?:\\;))+\s*(?:(?!\\:).[:])\s*(?!\s)((?:\\;|[^;])+?)(?=\s*(?:[;]|}}$))/i), []);
@@ -99,13 +99,17 @@ export const interpolate = (text: string, vars: Record<any, any> = {}, customMod
   }
 };
 
-export const translate: Translate = ({ translation, translations = {}, key, vars = {}, customModifiers = {}, locale, fallbackLocale }) => {
+export const translate: Translate = ({ translation, translations = {}, key, vars, customModifiers = {}, locale, fallbackLocale }) => {
   if (!key) throw new Error('no key provided to $t()');
 
   let text = useDefault(translation)[key];
 
   if (fallbackLocale && text === undefined) {
     text = useDefault(translations[fallbackLocale])[key];
+  }
+
+  if (vars?.default && text === undefined) {
+    text = `${vars.default}`;
   }
 
   if (text === undefined) {

--- a/tests/specs/index.spec.ts
+++ b/tests/specs/index.spec.ts
@@ -307,6 +307,14 @@ describe('translation', () => {
 
     expect($t('common.placeholder_default')).toBe('VALUES: DEFAULT_VALUE, DEFAULT_VALUE, DEFAULT_VALUE, DEFAULT_VALUE');
   });
+  it('dynamic default works for placeholders', async () => {
+    const { t, loadConfig } = new i18n();
+
+    await loadConfig(CONFIG);
+    const $t = t.get;
+
+    expect($t('common.placeholder_unknown', { default: 'DYNAMIC_DEFAULT_VALUE' })).toBe('DYNAMIC_DEFAULT_VALUE');
+  });
   it('placeholders containing escaped values work', async () => {
     const { t, loadConfig } = new i18n();
 


### PR DESCRIPTION
For example:

```javascript
$t('common.placeholder_unknown', { default: 'DYNAMIC_DEFAULT_VALUE' });
```

Also another translation can be used as default:

```javascript
$t(`error.${code}`, { default: $t('error.default') });
```